### PR TITLE
Register Bar and BarList types

### DIFF
--- a/pkg/apis/samplecontroller/v1alpha1/register.go
+++ b/pkg/apis/samplecontroller/v1alpha1/register.go
@@ -47,6 +47,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Foo{},
 		&FooList{},
+		&Bar{},
+		&BarList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil


### PR DESCRIPTION
Resolves the `no kind "Bar" is registered` error message (and its neighbor) mentioned in https://github.com/grantr/helloworld-crd/pull/12#issuecomment-356336251.

```
I0112 20:50:37.161392       1 controller.go:108] Setting up event handlers
I0112 20:50:37.161678       1 controller.go:108] Setting up event handlers
I0112 20:50:37.161870       1 controller.go:129] Starting Bar controller
I0112 20:50:37.161940       1 controller.go:132] Waiting for informer caches to sync
I0112 20:50:37.164310       1 controller.go:129] Starting Foo controller
I0112 20:50:37.164411       1 controller.go:132] Waiting for informer caches to sync
I0112 20:50:37.262281       1 controller.go:137] Starting workers
I0112 20:50:37.262552       1 controller.go:143] Started workers
I0112 20:50:37.264635       1 controller.go:137] Starting workers
I0112 20:50:37.264745       1 controller.go:143] Started workers
I0112 20:50:46.523812       1 controller.go:199] Successfully synced 'default/example-bar'
I0112 20:50:46.523885       1 event.go:218] Event(v1.ObjectReference{Kind:"Bar", Namespace:"default", Name:"example-bar", UID:"437c0b91-f7da-11e7-a2b5-42010a800318", APIVersion:"samplecontroller.k8s.io", ResourceVersion:"453349", FieldPath:""}): type: 'Normal' reason: 'Synced' Bar synced successfully
```

/cc @mattmoor